### PR TITLE
Map sets proper zoom after search or campus change has been conducted

### DIFF
--- a/src/app/components/outdoor/google-map/google-map.component.ts
+++ b/src/app/components/outdoor/google-map/google-map.component.ts
@@ -459,6 +459,8 @@ export class GoogleMapComponent implements OnInit {
     }
   };
 
+  private readonly defaultCampusZoom = 17;
+
   constructor(
     private platform: Platform,
     private geolocationServices: GeolocationServices,
@@ -549,6 +551,7 @@ export class GoogleMapComponent implements OnInit {
     this.events.subscribe('campusChanged', () => {
       this.poiMarkers = [];
       this.currentToggles = this.poiServices.resetPOIMarkers();
+      this.map.zoom = this.defaultCampusZoom;
     });
   }
 
@@ -561,6 +564,10 @@ export class GoogleMapComponent implements OnInit {
       };
       this.positionMarkers = [];
       this.positionMarkers.push(tempMarker);
+      if(coordinates.mapBounds)
+      {
+        this.map.fitBounds(coordinates.mapBounds)
+      }
     });
 
     this.data.currentMessage.subscribe(incomingMessage => {

--- a/src/app/components/outdoor/outdoor-navigation-toolbar/outdoor-navigation-toolbar.component.ts
+++ b/src/app/components/outdoor/outdoor-navigation-toolbar/outdoor-navigation-toolbar.component.ts
@@ -43,7 +43,7 @@ export class OutdoorNavigationToolbarComponent
   ];
 
   constructor(
-    private dataSharing: DataSharingService,
+    private dataSharingService: DataSharingService,
     private events: Events,
     public mapsAPILoader: MapsAPILoader,
     public ngZone: NgZone,
@@ -52,7 +52,7 @@ export class OutdoorNavigationToolbarComponent
     private translate: TranslationService,
     private geolocationServices: GeolocationServices
   ) {
-    this.dataSharing.currentMessage.subscribe(
+    this.dataSharingService.currentMessage.subscribe(
       incomingMessage => (this.message = incomingMessage)
     );
     this.directionService.isDirectionSet.subscribe(isDirectionSet => {
@@ -88,17 +88,15 @@ export class OutdoorNavigationToolbarComponent
 
         searchAutocomplete.addListener('place_changed', () => {
           this.ngZone.run(() => {
-            //get the place result
             let place: google.maps.places.PlaceResult = searchAutocomplete.getPlace();
 
-            //verify result
-            if (place.geometry === undefined || place.geometry === null) {
+            if (!place.geometry) {
               return;
             }
 
             this.latitudeFound = place.geometry.location.lat();
             this.longitudeFound = place.geometry.location.lng();
-            this.moveToFoundLocation(this.latitudeFound, this.longitudeFound);
+            this.moveToFoundLocation(this.latitudeFound, this.longitudeFound, place.geometry.viewport);
           });
         });
       });
@@ -112,13 +110,13 @@ export class OutdoorNavigationToolbarComponent
     if (this.loc == '2') {
       this.loc = '0';
     }
-    this.dataSharing.updateMessage(this.locations[this.loc]);
+    this.dataSharingService.updateMessage(this.locations[this.loc]);
     this.events.publish('campusChanged', Date.now());
   }
 
-  public moveToFoundLocation(lat: number, lng: number) {
-    this.dataSharing.updateMessage({ latitude: lat, longitude: lng });
-    this.events.publish('campusChanged', Date.now());
+  public moveToFoundLocation(lat: number, lng: number, mapBounds: any) {
+    this.dataSharingService.updateMessage({ latitude: lat, longitude: lng, mapBounds: mapBounds });
+    this.events.publish('coordinatesChanged', { latitude: lat, longitude: lng, mapBounds: mapBounds });
   }
 
   public closeAutocomplete($event: CustomEvent) {


### PR DESCRIPTION
Screenshots would not make sense so here is the description.
Now if You search for Canada, it will zoom out to Canada, search for concordia will zoom in toonly fit bounds of the Concordia downtown, let's say.

On campus change the map is set to the default campus zoom as well, so from Canada -> Change campus will zoom in to see the campus.