### PR TITLE
exit popover enhancements

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { UserServices } from 'src/services/user.services';
 import { TranslationService } from '../services/translation.service';
 import { Router } from '@angular/router';
 import { GoogleMapComponent } from './components/outdoor/google-map/google-map.component';
+import { OutdoorNavigationSideButtonsComponent} from "./components/outdoor/outdoor-navigation-side-buttons/outdoor-navigation-side-buttons.component";
 
 @Component({
   selector: 'app-root',
@@ -18,7 +19,7 @@ export class AppComponent {
   private concordiaRed: string = '#800000';
   message: any;
   subscribe: any;
-
+  isOpen: boolean;
   constructor(
     private platform: Platform,
     private splashScreen: SplashScreen,
@@ -30,17 +31,19 @@ export class AppComponent {
     private translationService: TranslationService
   ) {
     this.initializeApp();
+    this.isOpen = false;
     this.subscribe = this.platform.backButton.subscribeWithPriority(
       666666,
       () => {
         //&& !this.googleMapComp.isOpen
-        if (this.router.url == '/outdoor' && !GoogleMapComponent.isOpen) {
+        if (this.router.url == '/outdoor' && !GoogleMapComponent.isOpen && !this.isOpen && !OutdoorNavigationSideButtonsComponent.isOpen) {
           this.confirmMessage();
         }
       }
     );
   }
   async confirmMessage() {
+    this.isOpen = true;
     let alert = await this.alertController.create({
       header: this.translationService.getTranslation('Do you want to quit?'),
       cssClass: 'alert-css',
@@ -51,6 +54,7 @@ export class AppComponent {
           role: 'cancel',
           handler: () => {
             // close popup
+            this.isOpen = false;
           },
         },
         {
@@ -58,11 +62,13 @@ export class AppComponent {
           cssClass: 'alert-button-map',
           role: 'quit',
           handler: () => {
+            this.isOpen = false;
             navigator['app'].exitApp();
           },
         },
       ],
     });
+    this.isOpen = true;
     await alert.present();
   }
 

--- a/src/app/components/outdoor/outdoor-navigation-side-buttons/outdoor-navigation-side-buttons.component.ts
+++ b/src/app/components/outdoor/outdoor-navigation-side-buttons/outdoor-navigation-side-buttons.component.ts
@@ -26,6 +26,7 @@ export class OutdoorNavigationSideButtonsComponent implements OnInit {
   public isClassToClass: boolean = false;
   public isClassToBuilding: boolean = false;
   public isBuildingToClass: boolean = false;
+  static isOpen: boolean = false;
 
   constructor(
     public popoverController: PopoverController,
@@ -82,6 +83,7 @@ export class OutdoorNavigationSideButtonsComponent implements OnInit {
   }
 
   async openViewer() {
+    OutdoorNavigationSideButtonsComponent.isOpen = true;
     const modal = await this.modalController.create({
       component: ViewerModalComponent,
       componentProps: {
@@ -92,13 +94,22 @@ export class OutdoorNavigationSideButtonsComponent implements OnInit {
       showBackdrop: true
     });
 
+    modal.onDidDismiss().then(() => {
+      OutdoorNavigationSideButtonsComponent.isOpen = false;
+    });
+
     return await modal.present();
   }
 
   async openCalendar() {
+    OutdoorNavigationSideButtonsComponent.isOpen = true;
     const modal = await this.modalController.create({
       component: CalendarComponent
     })
+
+    modal.onDidDismiss().then(() => {
+      OutdoorNavigationSideButtonsComponent.isOpen = false;
+    });
 
     return await modal.present();
   }
@@ -138,11 +149,16 @@ export class OutdoorNavigationSideButtonsComponent implements OnInit {
   }
 
   async presentPopover(ev: any, mode: string) {
+    OutdoorNavigationSideButtonsComponent.isOpen = true;
     if (mode === 'search') {
       const popover = await this.popoverController.create({
         component: SearchPopoverComponent,
         event: ev,
         translucent: false
+      });
+
+      popover.onDidDismiss().then(() => {
+        OutdoorNavigationSideButtonsComponent.isOpen = false;
       });
 
       popover.style.cssText =
@@ -158,6 +174,7 @@ export class OutdoorNavigationSideButtonsComponent implements OnInit {
       });
 
       popover.onDidDismiss().then(() => {
+        OutdoorNavigationSideButtonsComponent.isOpen = false;
         this.poiClicked = false;
       });
 


### PR DESCRIPTION
-If the exit popup is already displayed, clicking on the android back button won't create a new one
-popup doesn't show up when clicking on other popovers such as poi popover, calendar popover, shuttle bus schedule, location search
-Back button on android now can only be used to exit when on  /outdoor 